### PR TITLE
fix: improve checkout page error handling and prevent serverless crashes

### DIFF
--- a/apps/students/app/checkout/[id]/page.tsx
+++ b/apps/students/app/checkout/[id]/page.tsx
@@ -19,8 +19,18 @@ export default async function CheckoutPage({ params }: PageProps) {
     
     // Safe check for id
     if (!resolvedParams?.id) {
+      console.error('CheckoutPage: Missing course ID');
       notFound();
     }
+
+    // Validate UUID format
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(resolvedParams.id)) {
+      console.error('CheckoutPage: Invalid course ID format:', resolvedParams.id);
+      notFound();
+    }
+
+    console.log('CheckoutPage: Fetching course data for ID:', resolvedParams.id);
 
     const headersList = await headers();
     
@@ -40,16 +50,39 @@ export default async function CheckoutPage({ params }: PageProps) {
       forwardHeaders['origin'] = `https://${hostHeader}`;
     }
     
-    // Fetch course data server-side
-    const course = await getCourseById(resolvedParams.id, forwardHeaders);
+    // Fetch course data server-side with timeout protection
+    let course;
+    try {
+      course = await Promise.race([
+        getCourseById(resolvedParams.id, forwardHeaders),
+        new Promise((_, reject) => 
+          setTimeout(() => reject(new Error('Course fetch timeout')), 15000)
+        )
+      ]);
+    } catch (fetchError) {
+      console.error('CheckoutPage: Failed to fetch course data:', fetchError);
+      // Return a fallback that will use client-side data fetching
+      return <CheckoutClient courseId={resolvedParams.id} initialCourseData={null} />;
+    }
     
     if (!course) {
+      console.error('CheckoutPage: Course not found for ID:', resolvedParams.id);
       notFound();
     }
     
+    console.log('CheckoutPage: Successfully fetched course data');
     return <CheckoutClient courseId={resolvedParams.id} initialCourseData={course} />;
   } catch (error) {
-    console.error('Error in checkout page:', error);
+    console.error('CheckoutPage: Unexpected error:', error);
+    // Fallback to client-side rendering instead of crashing
+    try {
+      const resolvedParams = await params;
+      if (resolvedParams?.id) {
+        return <CheckoutClient courseId={resolvedParams.id} initialCourseData={null} />;
+      }
+    } catch (fallbackError) {
+      console.error('CheckoutPage: Fallback failed:', fallbackError);
+    }
     notFound();
   }
 }

--- a/apps/students/app/services/course.service.ts
+++ b/apps/students/app/services/course.service.ts
@@ -27,6 +27,7 @@ export async function getCourseById(courseId: string, customHeaders?: HeadersIni
     const response = await fetch(`${API_ENDPOINTS.COURSES}/${courseId}`, {
       next: { revalidate: 60 }, // Cache for 60 seconds
       headers: headersObj,
+      signal: AbortSignal.timeout(10000), // 10 second timeout
     });
 
     if (!response.ok) {


### PR DESCRIPTION
- Add timeout protection for API calls (10s timeout)
- Add UUID validation for course ID
- Add comprehensive error logging
- Add fallback to client-side rendering when server-side fetch fails
- Prevent serverless function crashes with graceful error handling

This should resolve the 500 INTERNAL_SERVER_ERROR on checkout pages.

🤖 Generated with [Claude Code](https://claude.ai/code)