### PR TITLE
fix: resolve dynamic server usage error in checkout page

### DIFF
--- a/apps/students/app/checkout/[id]/page.tsx
+++ b/apps/students/app/checkout/[id]/page.tsx
@@ -1,5 +1,3 @@
-import { headers } from "next/headers";
-import { getCourseById } from "../../services/course.service";
 import CheckoutClient from './checkout-client';
 import { notFound } from 'next/navigation';
 
@@ -7,88 +5,34 @@ interface PageProps {
   params: Promise<{ id: string }>;
 }
 
-// Generate static params for build time - returns empty array for dynamic generation
-export async function generateStaticParams() {
-  // Return empty array to allow all dynamic routes
-  return [];
-}
+// Force dynamic rendering because we use headers()
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const fetchCache = 'force-no-store';
 
 export default async function CheckoutPage({ params }: PageProps) {
-  try {
-    const resolvedParams = await params;
-    
-    // Safe check for id
-    if (!resolvedParams?.id) {
-      console.error('CheckoutPage: Missing course ID');
-      notFound();
-    }
-
-    // Check for build-time placeholder
-    if (resolvedParams.id === '[id]') {
-      console.error('CheckoutPage: Received placeholder [id] - this should not happen in production');
-      notFound();
-    }
-
-    // Validate UUID format
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(resolvedParams.id)) {
-      console.error('CheckoutPage: Invalid course ID format:', resolvedParams.id);
-      notFound();
-    }
-
-    console.log('CheckoutPage: Fetching course data for ID:', resolvedParams.id);
-
-    const headersList = await headers();
-    
-    // Extract cookies, authorization, and origin headers for API calls
-    const cookieHeader = headersList.get('cookie');
-    const authHeader = headersList.get('authorization');
-    const hostHeader = headersList.get('host');
-    
-    const forwardHeaders: HeadersInit = {};
-    if (cookieHeader) {
-      forwardHeaders['cookie'] = cookieHeader;
-    }
-    if (authHeader) {
-      forwardHeaders['authorization'] = authHeader;
-    }
-    if (hostHeader) {
-      forwardHeaders['origin'] = `https://${hostHeader}`;
-    }
-    
-    // Fetch course data server-side with timeout protection
-    let course;
-    try {
-      course = await Promise.race([
-        getCourseById(resolvedParams.id, forwardHeaders),
-        new Promise((_, reject) => 
-          setTimeout(() => reject(new Error('Course fetch timeout')), 15000)
-        )
-      ]);
-    } catch (fetchError) {
-      console.error('CheckoutPage: Failed to fetch course data:', fetchError);
-      // Return a fallback that will use client-side data fetching
-      return <CheckoutClient courseId={resolvedParams.id} initialCourseData={null} />;
-    }
-    
-    if (!course) {
-      console.error('CheckoutPage: Course not found for ID:', resolvedParams.id);
-      notFound();
-    }
-    
-    console.log('CheckoutPage: Successfully fetched course data');
-    return <CheckoutClient courseId={resolvedParams.id} initialCourseData={course} />;
-  } catch (error) {
-    console.error('CheckoutPage: Unexpected error:', error);
-    // Fallback to client-side rendering instead of crashing
-    try {
-      const resolvedParams = await params;
-      if (resolvedParams?.id) {
-        return <CheckoutClient courseId={resolvedParams.id} initialCourseData={null} />;
-      }
-    } catch (fallbackError) {
-      console.error('CheckoutPage: Fallback failed:', fallbackError);
-    }
+  const resolvedParams = await params;
+  
+  // Safe check for id
+  if (!resolvedParams?.id) {
+    console.error('CheckoutPage: Missing course ID');
     notFound();
   }
+
+  // Check for build-time placeholder
+  if (resolvedParams.id === '[id]') {
+    console.error('CheckoutPage: Received placeholder [id] - this should not happen in production');
+    notFound();
+  }
+
+  // Validate UUID format
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!uuidRegex.test(resolvedParams.id)) {
+    console.error('CheckoutPage: Invalid course ID format:', resolvedParams.id);
+    notFound();
+  }
+
+  // For checkout pages, we'll use client-side data fetching
+  // This avoids the headers() issue during static generation
+  return <CheckoutClient courseId={resolvedParams.id} initialCourseData={null} />;
 }


### PR DESCRIPTION
- Remove headers() usage to avoid static generation conflicts
- Use client-side data fetching for checkout page
- Add proper runtime configuration (force-dynamic, nodejs runtime)
- Simplify checkout page to avoid build-time issues

This fixes the "Page changed from static to dynamic at runtime" error.

🤖 Generated with [Claude Code](https://claude.ai/code)